### PR TITLE
Convert CLI to use named arguments instead of positional arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,19 @@
 # soci-wrapper
+
+A wrapper for the [SOCI](https://github.com/awslabs/soci-snapshotter) (Seekable OCI) snapshotter tool.
+
+## Usage
+
+```
+soci-wrapper --repo REPOSITORY_NAME --digest IMAGE_DIGEST --region AWS_REGION --account AWS_ACCOUNT
+```
+
+### Options
+
+- `--repo` - Repository name (required)
+- `--digest` - Image digest (required)
+- `--region` - AWS region (required)
+- `--account` - AWS account ID (required)
 Build and push a SOCI index in an alternative way.
 
 * You do not need any other dependencies (such as containerd or zlib) installed.

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"os"
 	"sort"
@@ -195,13 +196,28 @@ func process(ctx context.Context, repo string, digest string, region string, acc
 }
 
 func main() {
-	if len(os.Args) < 4 {
-		fmt.Println("Usage: soci-wrapper REPOSITORY_NAME IMAGE_DIGEST AWS_REGION AWS_ACCOUNT")
+	// Define flags for named arguments
+	repoPtr := flag.String("repo", "", "Repository name (required)")
+	digestPtr := flag.String("digest", "", "Image digest (required)")
+	regionPtr := flag.String("region", "", "AWS region (required)")
+	accountPtr := flag.String("account", "", "AWS account ID (required)")
+	
+	// Define custom usage message
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: soci-wrapper --repo REPOSITORY_NAME --digest IMAGE_DIGEST --region AWS_REGION --account AWS_ACCOUNT\n\n")
+		fmt.Fprintf(os.Stderr, "Options:\n")
+		flag.PrintDefaults()
+	}
+
+	// Parse flags
+	flag.Parse()
+
+	// Validate required flags
+	if *repoPtr == "" || *digestPtr == "" || *regionPtr == "" || *accountPtr == "" {
+		fmt.Println("Error: All arguments are required")
+		flag.Usage()
 		os.Exit(1)
 	}
-	repo := os.Args[1]
-	digest := os.Args[2]
-	region := os.Args[3]
-	account := os.Args[4]
-	process(context.TODO(), repo, digest, region, account)
+
+	process(context.TODO(), *repoPtr, *digestPtr, *regionPtr, *accountPtr)
 }


### PR DESCRIPTION
## Changes

This PR improves the CLI argument handling by converting from positional arguments to named arguments.

### Implemented Changes

1. **Named Arguments Implementation**:
   - Utilized the Go standard library `flag` package
   - Added the following flags:
     - `--repo`: Repository name (required)
     - `--digest`: Image digest (required)
     - `--region`: AWS region (required)
     - `--account`: AWS account ID (required)

2. **Help Message Enhancement**:
   - Implemented custom usage message
   - Added descriptions for each argument

3. **README Update**:
   - Reflected the new CLI usage

### Usage Example

Before:
```
soci-wrapper REPOSITORY_NAME IMAGE_DIGEST AWS_REGION AWS_ACCOUNT
```

After:
```
soci-wrapper --repo REPOSITORY_NAME --digest IMAGE_DIGEST --region AWS_REGION --account AWS_ACCOUNT
```

This change improves command line usability and makes the purpose of each argument clearer.
